### PR TITLE
Update coupons to be specific

### DIFF
--- a/app/controllers/concerns/couponing/crud_controller_methods.rb
+++ b/app/controllers/concerns/couponing/crud_controller_methods.rb
@@ -43,7 +43,9 @@ module Couponing
             @coupon.errors.add(:base, "How many must be positive")
             flash[:coupon_error] = "How many must be positive"
           end
-          offers = @coupon.validate_new_offers(offer_params[:offers])
+          offers = offer_params[:offers].select(&:present?).map {|offer_code| Offer.new(code: offer_code)}
+          @coupon.offers = offers
+
           if @coupon.errors.empty? && @coupon.valid?
             create_count = 0
             Integer(num_requested).times do |i|
@@ -70,14 +72,13 @@ module Couponing
 
     def update
       load_coupon
-      @coupon.update_offers(offer_params[:offers])
+
+      @coupon.update_coupon_offers(coupon_params, offer_params[:offers])
 
       if @coupon.errors.messages.present?
         render action: "edit"
-      elsif @coupon.update coupon_params
-        redirect_to coupon_redirect_path(after: @first_coupon)
       else
-        render action: "edit"
+        redirect_to coupon_redirect_path(after: @first_coupon)
       end
     end
 

--- a/app/controllers/concerns/couponing/crud_controller_methods.rb
+++ b/app/controllers/concerns/couponing/crud_controller_methods.rb
@@ -87,9 +87,7 @@ module Couponing
     end
 
     def load_offers
-      # TODO: maybe constants are better here?
-      offerables = Offer.distinct(:offerable_type).pluck(:offerable_type).collect {|o| o.constantize.all}.flatten
-      @available_offers = offerables.map {|o| Offer.find_or_initialize_by(offerable_id: o.id, offerable_type: o.class.name, coupon_id: @coupon.id) }
+      @available_offers = @coupon.available_offers
     end
 
     def coupon_params

--- a/app/models/concerns/couponing/offer_specifics.rb
+++ b/app/models/concerns/couponing/offer_specifics.rb
@@ -10,4 +10,5 @@ module Couponing::OfferSpecifics
   end
 
   def offer_list; end
+  def available_offers; end
 end

--- a/app/models/concerns/couponing/offer_specifics.rb
+++ b/app/models/concerns/couponing/offer_specifics.rb
@@ -10,5 +10,7 @@ module Couponing::OfferSpecifics
   end
 
   def offer_list; end
-  def available_offers; end
+  def available_offers
+    []
+  end
 end

--- a/app/models/concerns/couponing/offer_specifics.rb
+++ b/app/models/concerns/couponing/offer_specifics.rb
@@ -1,0 +1,13 @@
+module Couponing::OfferSpecifics
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :offers, dependent: :destroy
+
+    accepts_nested_attributes_for :offers, allow_destroy: true
+  
+    validates :offers, presence: true
+  end
+
+  def offer_list; end
+end

--- a/app/models/concerns/couponing/offer_specifics.rb
+++ b/app/models/concerns/couponing/offer_specifics.rb
@@ -1,15 +1,9 @@
 module Couponing::OfferSpecifics
   extend ActiveSupport::Concern
 
-  included do
-    has_many :offers, dependent: :destroy
-
-    accepts_nested_attributes_for :offers, allow_destroy: true
-  
-    validates :offers, presence: true
+  def offer_list
+    ""
   end
-
-  def offer_list; end
   def available_offers
     []
   end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -2,12 +2,8 @@ require 'errors'
 
 
 class Coupon < ActiveRecord::Base
+  include Couponing::OfferSpecifics
   has_many :redemptions
-  has_many :offers, dependent: :destroy
-
-  accepts_nested_attributes_for :offers, allow_destroy: true
-
-  validates :offers, presence: true
 
   validates :name, :presence => true
 

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -3,6 +3,7 @@ require 'errors'
 
 class Coupon < ActiveRecord::Base
   has_many :redemptions
+  has_many :offers, as: :offerable
 
   validates :name, :presence => true
 

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -3,7 +3,12 @@ require 'errors'
 
 class Coupon < ActiveRecord::Base
   include Couponing::OfferSpecifics
+
   has_many :redemptions
+
+  has_many :offers, dependent: :destroy
+  accepts_nested_attributes_for :offers, allow_destroy: true
+  validates :offers, presence: true
 
   validates :name, :presence => true
 

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -3,8 +3,11 @@ require 'errors'
 
 class Coupon < ActiveRecord::Base
   has_many :redemptions
-  has_many :offers, as: :offerable, dependent: :destroy
-  validates_presence_of :offers
+  has_many :offers, dependent: :destroy
+
+  accepts_nested_attributes_for :offers, allow_destroy: true
+
+  validates :offers, presence: true
 
   validates :name, :presence => true
 

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -145,8 +145,8 @@ class Coupon < ActiveRecord::Base
     updated_codes = codes.select(&:present?)
     added_codes = updated_codes - existing_codes
     removed_codes = existing_codes - updated_codes
-    removed_offers = existing_offers.where(code: removed_codes).destroy_all
-
+    
+    existing_offers.where(code: existing_codes - updated_codes).destroy_all
     added_codes.map {|code| self.offers << Offer.new(code: code) }
   end
    

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -129,25 +129,6 @@ class Coupon < ActiveRecord::Base
   def can_edit?
     self.redemptions.empty?
   end
-
-  def update_coupon_offers(coupon, offer_codes)
-    Coupon.transaction do
-      self.update_offers(offer_codes)
-      self.update(coupon)
-    end
-  end
-
-  def update_offers(codes)
-    existing_offers = self.offers.select(:id,:code)
-    existing_codes = existing_offers.pluck(:code)
-
-    updated_codes = codes.select(&:present?)
-    added_codes = updated_codes - existing_codes
-    removed_codes = existing_codes - updated_codes
-    
-    existing_offers.where(code: existing_codes - updated_codes).destroy_all
-    added_codes.map {|code| self.offers << Offer.new(code: code) }
-  end
    
   private
   

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,0 +1,5 @@
+class Offer < ActiveRecord::Base
+  belongs_to :offerable, polymorphic: true
+
+  validates :code, presence: true
+end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,5 +1,6 @@
 class Offer < ActiveRecord::Base
   belongs_to :offerable, polymorphic: true
 
+  include OfferSpecifics
   validates :code, presence: true
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,6 +1,4 @@
 class Offer < ActiveRecord::Base
   belongs_to :offerable, polymorphic: true
-
-  include OfferSpecifics
-  validates :code, presence: true
+  belongs_to :coupon
 end

--- a/lib/generators/couponing/couponing_generator.rb
+++ b/lib/generators/couponing/couponing_generator.rb
@@ -16,5 +16,6 @@ class CouponingGenerator < Rails::Generators::Base
 
   def create_migration_file
     migration_template 'migration.rb', 'db/migrate/create_couponing_table.rb'
+    migration_template 'offers_migratrion.rb', 'db/migrate/create_offers_table.rb'
   end
 end

--- a/lib/generators/couponing/templates/offers_migration.rb
+++ b/lib/generators/couponing/templates/offers_migration.rb
@@ -1,0 +1,10 @@
+class CreateOffers < ActiveRecord::Migration
+  def change
+    create_table :offers do |t|
+      t.string :code, limit: 255
+      t.references :offerable, polymorphic: true, index: true, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/lib/generators/couponing/templates/offers_migration.rb
+++ b/lib/generators/couponing/templates/offers_migration.rb
@@ -1,8 +1,8 @@
 class CreateOffers < ActiveRecord::Migration
   def change
     create_table :offers do |t|
-      t.string :code, limit: 255
       t.references :offerable, polymorphic: true, index: true, null: false
+      t.references :coupon, index: true, null: false
 
       t.timestamps null: false
     end

--- a/test/dummy/db/migrate/20220704221232_create_offers_table.rb
+++ b/test/dummy/db/migrate/20220704221232_create_offers_table.rb
@@ -1,0 +1,10 @@
+class CreateOffersTable < ActiveRecord::Migration
+  def change
+    create_table :offers do |t|
+      t.string :code, limit: 255
+      t.references :offerable, polymorphic: true, index: true, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/migrate/20220704221232_create_offers_table.rb
+++ b/test/dummy/db/migrate/20220704221232_create_offers_table.rb
@@ -1,8 +1,8 @@
 class CreateOffersTable < ActiveRecord::Migration
   def change
     create_table :offers do |t|
-      t.string :code, limit: 255
       t.references :offerable, polymorphic: true, index: true, null: false
+      t.references :coupon, index: true, null: false
 
       t.timestamps null: false
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -8,11 +9,11 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110207215013) do
+ActiveRecord::Schema.define(version: 20220704221232) do
 
-  create_table "coupons", :force => true do |t|
+  create_table "coupons", force: :cascade do |t|
     t.string   "name"
     t.string   "description"
     t.text     "metadata"
@@ -21,23 +22,33 @@ ActiveRecord::Schema.define(:version => 20110207215013) do
     t.string   "digit_code"
     t.string   "digit_mask"
     t.string   "category_one"
-    t.float    "amount_one",        :default => 0.0
-    t.float    "percentage_one",    :default => 0.0
+    t.float    "amount_one",        default: 0.0
+    t.float    "percentage_one",    default: 0.0
     t.string   "category_two"
-    t.float    "amount_two",        :default => 0.0
-    t.float    "percentage_two",    :default => 0.0
+    t.float    "amount_two",        default: 0.0
+    t.float    "percentage_two",    default: 0.0
     t.date     "expiration"
-    t.integer  "how_many",          :default => 1
-    t.integer  "redemptions_count", :default => 0
-    t.integer  "integer",           :default => 0
+    t.integer  "how_many",          default: 1
+    t.integer  "redemptions_count", default: 0
+    t.integer  "integer",           default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "coupons", ["alpha_code"], :name => "index_coupons_on_alpha_code"
-  add_index "coupons", ["digit_code"], :name => "index_coupons_on_digit_code"
+  add_index "coupons", ["alpha_code"], name: "index_coupons_on_alpha_code"
+  add_index "coupons", ["digit_code"], name: "index_coupons_on_digit_code"
 
-  create_table "redemptions", :force => true do |t|
+  create_table "offers", force: :cascade do |t|
+    t.string   "code",           limit: 255
+    t.integer  "offerable_id",               null: false
+    t.string   "offerable_type",             null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "offers", ["offerable_type", "offerable_id"], name: "index_offers_on_offerable_type_and_offerable_id"
+
+  create_table "redemptions", force: :cascade do |t|
     t.integer  "coupon_id"
     t.string   "user_id"
     t.string   "transaction_id"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -37,15 +37,16 @@ ActiveRecord::Schema.define(version: 20220704221232) do
 
   add_index "coupons", ["alpha_code"], name: "index_coupons_on_alpha_code"
   add_index "coupons", ["digit_code"], name: "index_coupons_on_digit_code"
-
+  
   create_table "offers", force: :cascade do |t|
-    t.string   "code",           limit: 255
-    t.integer  "offerable_id",               null: false
-    t.string   "offerable_type",             null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.integer  "offerable_id",   null: false
+    t.string   "offerable_type", null: false
+    t.integer  "coupon_id",      null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
   end
 
+  add_index "offers", ["coupon_id"], name: "index_offers_on_coupon_id", using: :btree
   add_index "offers", ["offerable_type", "offerable_id"], name: "index_offers_on_offerable_type_and_offerable_id"
 
   create_table "redemptions", force: :cascade do |t|


### PR DESCRIPTION
Before, coupons have been applied to any offer item generically. Since offered items are starting to vary greatly, we'd like to specify which certifications(s) a coupon is for. 

This update adapts the couponsgem to generate coupons that are specific to a subset of items, instead of coupons that apply to any item. Generic coupons will still work until they are expired or updated to be specific.

I kept this minimal to start. We could also update the generated views here too.